### PR TITLE
Fix for mintwelcome to start at runtime in MATE

### DIFF
--- a/etc/xdg/autostart/mintwelcome.desktop
+++ b/etc/xdg/autostart/mintwelcome.desktop
@@ -7,5 +7,5 @@ Exec=mintwelcome-launcher
 Terminal=false
 Type=Application
 Categories=
-OnlyShowIn=GNOME;XFCE;KDE;
+OnlyShowIn=GNOME;XFCE;KDE;MATE;
 


### PR DESCRIPTION
"MATE;" was missing from "OnlyShowIn".
