### PR TITLE
Convert mintwelcome to Python 3

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,17 +2,20 @@ Source: mintwelcome
 Section: admin
 Priority: optional
 Maintainer: Clement Lefebvre <root@linuxmint.com>
-Build-Depends: debhelper (>= 9), python
+Build-Depends: debhelper (>= 9),
+               dh-python
 Standards-Version: 3.9.5
 
 Package: mintwelcome
 Architecture: all
-Depends:
- ${python:Depends}, ${misc:Depends},
- python (>= 2.4), python (<< 3),
- python-gtk2, python-glade2,
- mint-info, mint-common, apturl | apturl-kde
+Depends: python3 (>= 3.3),
+         python3-gi,
+         mint-info,
+         mint-common,
+         apturl | apturl-kde,
+         ${misc:Depends},
+         ${python3:Depends},
 Conflicts: mintassistant, mintassistant-gnome, mintassistant-kde
 Replaces: mintassistant, mintassistant-gnome, mintassistant-kde
 Description: Welcome screen for Linux Mint
- Shows important information about the release/edition of Linux Mint. 
+ Shows important information about the release/edition of Linux Mint.

--- a/generate_desktop_files
+++ b/generate_desktop_files
@@ -1,9 +1,12 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 DOMAIN = "mintwelcome"
 PATH = "/usr/share/linuxmint/locale"
 
-import os, gettext, sys
+import os
+import gettext
+import sys
+
 sys.path.append('/usr/lib/linuxmint/common')
 import additionalfiles
 
@@ -47,4 +50,3 @@ StartupNotify=false
 """
 
 additionalfiles.generate(DOMAIN, PATH, "mint-meta-codecs.desktop", prefix, _("Install Multimedia Codecs"), _("Add all the missing multimedia codecs"), "")
-

--- a/usr/bin/mintwelcome
+++ b/usr/bin/mintwelcome
@@ -1,8 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import os
 
-os.system("python /usr/lib/linuxmint/mintWelcome/mintWelcome.py")
-
-
-
+os.system("/usr/lib/linuxmint/mintWelcome/mintWelcome.py")

--- a/usr/bin/mintwelcome-launcher
+++ b/usr/bin/mintwelcome-launcher
@@ -1,9 +1,11 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
-import os, commands
-from user import home
+import os
+import subprocess
 
-cmdline = commands.getoutput("cat /proc/cmdline")
+HOME = os.path.expanduser("~")
 
-if ((not os.path.exists(home + "/.linuxmint/mintWelcome/norun.flag")) and (not "boot=casper" in cmdline) and (not "boot=live" in cmdline)):
-	os.system("mintwelcome")
+cmdline = subprocess.getoutput("cat /proc/cmdline")
+
+if ((not os.path.exists(HOME + "/.linuxmint/mintWelcome/norun.flag")) and ("boot=casper" not in cmdline) and ("boot=live" not in cmdline)):
+    os.system("mintwelcome")

--- a/usr/lib/linuxmint/mintWelcome/mintWelcome.py
+++ b/usr/lib/linuxmint/mintWelcome/mintWelcome.py
@@ -1,24 +1,25 @@
-#!/usr/bin/env python
+#!/usr/bin/python3
 
 import gi
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, Gdk
-from gi.repository import WebKit
 from gi.repository.GdkPixbuf import Pixbuf
 
 import sys
-import commands
 import os
 import gettext
-from user import home
-import string
+import signal
+
+HOME = os.path.expanduser("~")
 
 # i18n
 gettext.install("mintwelcome", "/usr/share/linuxmint/locale")
 
-import signal
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 
+
 class MintWelcome():
+
     def __init__(self):
         window = Gtk.Window()
         window.set_title(_("Welcome Screen"))
@@ -26,7 +27,7 @@ class MintWelcome():
         window.set_position(Gtk.WindowPosition.CENTER)
         window.connect("destroy", Gtk.main_quit)
 
-        sys.path.append('/usr/lib/linuxmint/common')
+        sys.path.insert(1, '/usr/lib/linuxmint/common')
         from configobj import ConfigObj
         config = ConfigObj("/etc/linuxmint/info")
         codename = config['CODENAME'].capitalize()
@@ -44,9 +45,9 @@ class MintWelcome():
             self.dist_name = "LMDE"
             self.codec_pkg_name = "mint-meta-debian-codecs"
 
-        bgcolor =  Gdk.RGBA()
+        bgcolor = Gdk.RGBA()
         bgcolor.parse("rgba(0,0,0,0)")
-        fgcolor =  Gdk.RGBA()
+        fgcolor = Gdk.RGBA()
         fgcolor.parse("#3e3e3e")
 
         main_box = Gtk.VBox()
@@ -146,7 +147,7 @@ class MintWelcome():
         checkbox = Gtk.CheckButton()
         checkbox.set_label(_("Show this dialog at startup"))
         checkbox.override_color(Gtk.StateType.NORMAL, fgcolor)
-        if not os.path.exists(home + "/.linuxmint/mintWelcome/norun.flag"):
+        if not os.path.exists(HOME + "/.linuxmint/mintWelcome/norun.flag"):
             checkbox.set_active(True)
         checkbox.connect("toggled", self.on_button_toggled)
         hbox.pack_end(checkbox, False, False, 2)
@@ -172,16 +173,15 @@ class MintWelcome():
         style_context = window.get_style_context()
         style_context.add_provider_for_screen(screen, css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
 
-
         window.show_all()
 
     def on_button_toggled(self, button):
         if button.get_active():
-            if os.path.exists(home + "/.linuxmint/mintWelcome/norun.flag"):
-                os.system("rm -rf " + home + "/.linuxmint/mintWelcome/norun.flag")
+            if os.path.exists(HOME + "/.linuxmint/mintWelcome/norun.flag"):
+                os.system("rm -rf " + HOME + "/.linuxmint/mintWelcome/norun.flag")
         else:
-            os.system("mkdir -p " + home + "/.linuxmint/mintWelcome")
-            os.system("touch " + home + "/.linuxmint/mintWelcome/norun.flag")
+            os.system("mkdir -p " + HOME + "/.linuxmint/mintWelcome")
+            os.system("touch " + HOME + "/.linuxmint/mintWelcome/norun.flag")
 
     def item_activated(self, view):
         paths = view.get_selected_items()


### PR DESCRIPTION
#### Dependent on mint-common [PR #15](https://github.com/linuxmint/mint-common/pull/15)

Convert the mintwelcome package to use Python 3