### PR TITLE
Adds a link to run inxi with push to termbin.com

### DIFF
--- a/usr/lib/linuxmint/mintwelcome/mintwelcome.py
+++ b/usr/lib/linuxmint/mintwelcome/mintwelcome.py
@@ -3,6 +3,7 @@
 import os
 import gettext
 import signal
+import subprocess
 
 import gi
 gi.require_version("Gtk", "3.0")
@@ -171,6 +172,11 @@ class MintWelcome():
         hbox = Gtk.HBox()
         hbox.set_border_width(6)
         main_box.pack_end(hbox, False, False, 0)
+
+        linkbutton = Gtk.LinkButton("http://www.termbin.com", "Push system information to web for sharing")
+        linkbutton.connect("activate-link", self.on_activate_link)
+        hbox.pack_start(linkbutton, False, False, 2)
+
         checkbox = Gtk.CheckButton()
         checkbox.set_label(_("Show this dialog at startup"))
 
@@ -229,6 +235,34 @@ class MintWelcome():
         else:
             os.system("mkdir -p ~/.linuxmint/mintwelcome")
             os.system("touch %s" % NORUN_FLAG)
+
+    def on_activate_link(self, button):
+        dlg = Gtk.MessageDialog(button.get_toplevel(), 0, Gtk.MessageType.QUESTION, Gtk.ButtonsType.YES_NO, "Push system information to web for sharing")
+        dlg.format_secondary_markup("This will run the command <b>inxi -Fc0 | nc termbin.com 9999</b> to push your system information to termbin.com. You can then "
+                                    "share the provided link with others.")
+        dlg.set_modal(True)
+        response = dlg.run()
+        dlg.destroy()
+
+        if response == Gtk.ResponseType.YES:            
+            p1 = subprocess.Popen(["inxi", "-Fc0"], stdout=subprocess.PIPE)
+            p2 = subprocess.Popen(["nc", "termbin.com", "9999"], stdin=p1.stdout, stdout=subprocess.PIPE)
+            p1.stdout.close()
+            output = p2.communicate()
+
+            if output[0].startswith(b"http://"):
+                dlg2 = Gtk.MessageDialog(button.get_toplevel(), 0, Gtk.MessageType.INFO, Gtk.ButtonsType.OK, "Push system information to web for sharing")
+                dlg2.format_secondary_markup("The URL is <b>" + output[0].decode("utf-8").strip() + "</b>\n"
+                                             "You can share this URL to show others your system specifications.")
+                dlg2.run()
+                dlg2.destroy()
+            else:
+                dlg2 = Gtk.MessageDialog(button.get_toplevel(), 0, Gtk.MessageType.ERROR, Gtk.ButtonsType.CLOSE, "Push system information to web for sharing")
+                dlg2.format_secondary_markup("Unfortunately, the command did not work. Please run the command manually in a terminal.")
+                dlg2.run()
+                dlg2.destroy()
+        
+        return True
 
     def on_mouse_click(self, widget, event):
         if event.type == Gdk.EventType.BUTTON_PRESS:


### PR DESCRIPTION
Providing help in #linuxmint-chat/help requires practically always the basic system information of the users computer. For this, users are asked to input a command into a terminal, which runs inxi and pushes the results to a pastebin service (github gist or termbin).

Usually, this is no problem. However, sometimes it is a real hassle because the users have problems to input or copy the command to the terminal (since Ctrl+C/V do not work, etc). Sometimes they ignore the pipe running only inxi - usually with an attempt to copy the output directly to the above channels. Mintbotd complains naturally.

For such cases or all cases in general it would be nice to direct the users to a known place (the Welcome Screen - they got into #linuxmint-help from there after all) and tell them just to push a button to get the results.

This pull request implements such a way. It will add a linkbutton in the bottom left corner of the Welcome screen, asking the user if it can run the command and will - if successful - show the URL for simple copying. I have chosen termbin.com since pushed output only last one month (github is kind of permanent), but this can be changed of course.

I am not 100% happy with the labels, but this is easy to change.

![bildschirmfoto zu 2017-02-14_00-16-36](https://cloud.githubusercontent.com/assets/6428497/22916527/04c64f40-f24d-11e6-8478-b838d9b1e780.png)
