### PR TITLE
allow for window controls on the left

### DIFF
--- a/usr/share/linuxmint/mintwelcome/mintwelcome.ui
+++ b/usr/share/linuxmint/mintwelcome/mintwelcome.ui
@@ -11,7 +11,6 @@
         <property name="title" translatable="yes">Welcome</property>
         <property name="has_subtitle">False</property>
         <property name="show_close_button">True</property>
-        <property name="decoration_layout">:close</property>
         <child>
           <placeholder/>
         </child>


### PR DESCRIPTION
Window controls wouldn't move to the left if button layout so configured by user; decoration_layout=:close was blocking that. Removing it fixes that. Side-effect that a minimize and maximize button are now also shown.