### PR TITLE
remove unused import cairo

### DIFF
--- a/usr/lib/linuxmint/mintwelcome/mintwelcome.py
+++ b/usr/lib/linuxmint/mintwelcome/mintwelcome.py
@@ -6,7 +6,6 @@ import os
 import platform
 import subprocess
 import locale
-import cairo
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, Gio, Gdk, GdkPixbuf
 


### PR DESCRIPTION
Currently `cario` is not unused.