### PR TITLE
Evaluate the reported architecture from the LIBC pointer size

### DIFF
--- a/usr/lib/linuxmint/mintwelcome/mintwelcome.py
+++ b/usr/lib/linuxmint/mintwelcome/mintwelcome.py
@@ -3,7 +3,7 @@ import apt
 import gettext
 import gi
 import os
-import platform
+import struct
 import subprocess
 import locale
 gi.require_version("Gtk", "3.0")
@@ -53,9 +53,7 @@ class MintWelcome():
         desktop = config['DESKTOP']
         release_notes = config['RELEASE_NOTES_URL']
         new_features = config['NEW_FEATURES_URL']
-        architecture = "64-bit"
-        if platform.machine() != "x86_64":
-            architecture = "32-bit"
+        architecture = str(struct.calcsize('P') * 8) + "-bit"
 
         # distro-specific
         dist_name = "Linux Mint"


### PR DESCRIPTION
Evaluation of the bit width from the pointer size is architecture independent and won't require any modifications if a new architecture appears. I've tested the behavior with 32-bit LMDE and it reports the width correctly. The information is taken from LIBC (similar to getconf LONG_BIT) therefore it should not return wrong values even when someone runs 32-bit userspace on 64-bit kernel.